### PR TITLE
Drop Lending Iterator (`NodeIterator`)

### DIFF
--- a/crates/nodui/src/lib.rs
+++ b/crates/nodui/src/lib.rs
@@ -12,9 +12,10 @@
 //! # impl nodui::GraphAdapter for MyGraph {
 //! #    type NodeId = ();
 //! #    type SocketId = ();
-//! #    fn nodes(&mut self) -> impl nodui::NodeIterator<NodeId = Self::NodeId, SocketId = Self::SocketId> {
+//! #    fn nodes(&self) -> impl Iterator<Item: nodui::NodeAdapter<NodeId = Self::NodeId, SocketId = Self::SocketId>> {
 //! #        core::iter::empty::<Foo>()
 //! #    }
+//! #    fn set_node_pos(&mut self, node_id: Self::NodeId, pos: nodui::Pos) { }
 //! #    fn connection_hint(&self, a: Self::SocketId, b: Self::SocketId) -> nodui::ConnectionHint { unreachable!() }
 //! #    fn connect(&mut self, a: Self::SocketId, b: Self::SocketId) { }
 //! #    fn connections(&self) -> impl Iterator<Item = (Self::SocketId, Self::SocketId)> { std::iter::empty() }
@@ -27,7 +28,6 @@
 //! #    }
 //! #    fn id(&self) -> Self::NodeId { unreachable!() }
 //! #    fn pos(&self) -> nodui::Pos { unreachable!() }
-//! #    fn set_pos(&mut self, pos: nodui::Pos) { }
 //! # }
 //! # impl nodui::SocketAdapter for Foo {
 //! #   type SocketId = ();

--- a/crates/nodui_core/src/adapter.rs
+++ b/crates/nodui_core/src/adapter.rs
@@ -24,6 +24,9 @@ pub trait GraphAdapter {
         &self,
     ) -> impl Iterator<Item: NodeAdapter<NodeId = Self::NodeId, SocketId = Self::SocketId>>;
 
+    /// Set the position of a node.
+    fn set_node_pos(&mut self, node_id: Self::NodeId, pos: Pos);
+
     /// A hint about the connection between the sockets `a` and `b`.
     ///
     /// This hint is used to provide a feedback to the user before they submit the connection.
@@ -84,6 +87,11 @@ impl<'a, T: GraphAdapter + ?Sized> GraphAdapter for &'a mut T {
         &self,
     ) -> impl Iterator<Item: NodeAdapter<NodeId = Self::NodeId, SocketId = Self::SocketId>> {
         GraphAdapter::nodes(*self)
+    }
+
+    #[inline]
+    fn set_node_pos(&mut self, node_id: Self::NodeId, pos: Pos) {
+        GraphAdapter::set_node_pos(*self, node_id, pos);
     }
 
     #[inline]

--- a/crates/nodui_core/src/adapter.rs
+++ b/crates/nodui_core/src/adapter.rs
@@ -20,7 +20,9 @@ pub trait GraphAdapter {
     type SocketId: Id;
 
     /// An iterator over the node's adapters of the graph.
-    fn nodes(&mut self) -> impl NodeIterator<NodeId = Self::NodeId, SocketId = Self::SocketId>;
+    fn nodes(
+        &self,
+    ) -> impl Iterator<Item: NodeAdapter<NodeId = Self::NodeId, SocketId = Self::SocketId>>;
 
     /// A hint about the connection between the sockets `a` and `b`.
     ///
@@ -51,9 +53,6 @@ pub trait NodeAdapter {
     /// The current position of this node in the graph.
     fn pos(&self) -> Pos;
 
-    /// Set the position of this node in the graph.
-    fn set_pos(&mut self, pos: Pos);
-
     /// Defines how the node should be rendered.
     #[inline]
     fn ui(&self) -> NodeUI {
@@ -75,68 +74,15 @@ pub trait SocketAdapter {
 
 /* -------------------------------------------------------------------------- */
 
-/// A lending iterator over the node's adapters of a graph.
-pub trait NodeIterator {
-    /// An identifier used to identify a node over the graph.
-    type NodeId: Id;
-
-    /// An identifier used to identify a socket over the graph.
-    type SocketId: Id;
-
-    /// An adapter that represents a node.
-    type Item<'this>: NodeAdapter<NodeId = Self::NodeId, SocketId = Self::SocketId>
-    where
-        Self: 'this;
-
-    /// Advances the iterator and returns the next value.
-    ///
-    /// See [`Iterator::next`] for more details.
-    fn next(&mut self) -> Option<Self::Item<'_>>;
-
-    /// Returns the bounds on the remaining length of the iterator.
-    ///
-    /// This methods should be implemented the same way [`Iterator::size_hint`] is implemented.
-    ///
-    /// The default implementation returns <code>(0, [None])</code> which is correct for any
-    /// iterator.
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
-
-impl<I> NodeIterator for I
-where
-    I: Iterator,
-    I::Item: NodeAdapter,
-{
-    type NodeId = <I::Item as NodeAdapter>::NodeId;
-    type SocketId = <I::Item as NodeAdapter>::SocketId;
-
-    type Item<'this> = I::Item
-    where
-        Self: 'this;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item<'_>> {
-        Iterator::next(self)
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        Iterator::size_hint(self)
-    }
-}
-
-/* -------------------------------------------------------------------------- */
-
 #[warn(clippy::missing_trait_methods)]
 impl<'a, T: GraphAdapter + ?Sized> GraphAdapter for &'a mut T {
     type NodeId = T::NodeId;
     type SocketId = T::SocketId;
 
     #[inline]
-    fn nodes(&mut self) -> impl NodeIterator<NodeId = Self::NodeId, SocketId = Self::SocketId> {
+    fn nodes(
+        &self,
+    ) -> impl Iterator<Item: NodeAdapter<NodeId = Self::NodeId, SocketId = Self::SocketId>> {
         GraphAdapter::nodes(*self)
     }
 
@@ -176,11 +122,6 @@ impl<'a, T: NodeAdapter + ?Sized> NodeAdapter for &'a mut T {
     #[inline]
     fn pos(&self) -> Pos {
         NodeAdapter::pos(*self)
-    }
-
-    #[inline]
-    fn set_pos(&mut self, pos: Pos) {
-        NodeAdapter::set_pos(*self, pos);
     }
 
     #[inline]

--- a/crates/nodui_core/src/lib.rs
+++ b/crates/nodui_core/src/lib.rs
@@ -5,6 +5,4 @@
 pub mod adapter;
 pub mod ui;
 
-pub use crate::adapter::{
-    ConnectionHint, GraphAdapter, Id, NodeAdapter, NodeIterator, Pos, SocketAdapter,
-};
+pub use crate::adapter::{ConnectionHint, GraphAdapter, Id, NodeAdapter, Pos, SocketAdapter};

--- a/crates/nodui_egui/src/editor.rs
+++ b/crates/nodui_egui/src/editor.rs
@@ -494,10 +494,6 @@ impl<'a, G: GraphAdapter> GraphEditor<'a, G> {
 
         let mut last_interacted_node_id = None;
 
-        // let mut nodes = graph.nodes();
-
-        // let mut node_responses = Vec::with_capacity(nodes.size_hint().0);
-
         let node_responses = graph
             .nodes()
             .map(|node| {
@@ -533,90 +529,30 @@ impl<'a, G: GraphAdapter> GraphEditor<'a, G> {
                     ui.painter().add(node_painter);
                 }
 
-                if node_response.drag_stopped() {
-                    state.dragged_node = None;
-                    let _new_pos = pos + node_response.drag_delta();
-                    // TODO: set the position of the node
-                    // node.set_pos(viewport.grid.canvas_to_graph_nearest(new_pos));
-                } else if node_response.drag_started() {
-                    state.dragged_node = Some((node_id.clone(), node_response.drag_delta()));
-                } else if node_response.dragged() {
-                    if let Some(dragged_node) = state.dragged_node.as_mut() {
-                        dragged_node.1 += node_response.drag_delta();
-                    }
-                }
-
-                if node_response.clicked
-                    || node_response.fake_primary_click
-                    || node_response.dragged()
-                {
-                    last_interacted_node_id = Some(node_id.clone());
-                    state.set_node_on_top(node_id.clone());
-                }
-
                 // node_responses.push((node_id, node_response));
-                (node_id, node_response)
+                (node_id, node_response, pos)
             })
             .collect::<Vec<_>>();
 
-        // while let Some(mut node) = nodes.next() {
-        //     let node_id = node.id();
+        for (id, response, pos) in node_responses {
+            if response.drag_stopped() {
+                state.dragged_node = None;
+                let new_pos = pos + response.drag_delta();
+                graph.set_node_pos(id.clone(), viewport.grid.canvas_to_graph_nearest(new_pos));
+            } else if response.drag_started() {
+                state.dragged_node = Some((id.clone(), response.drag_delta()));
+            } else if response.dragged() {
+                if let Some(dragged_node) = state.dragged_node.as_mut() {
+                    dragged_node.1 += response.drag_delta();
+                }
+            }
 
-        //     // If this is a new node, insert it on top, does nothing otherwise.
-        //     state.node_order.insert(node_id.clone());
+            if response.clicked || response.fake_primary_click || response.dragged() {
+                last_interacted_node_id = Some(id.clone());
+                state.set_node_on_top(id.clone());
+            }
 
-        //     let pos = {
-        //         let delta_pos = match state.dragged_node.clone() {
-        //             Some((id, delta_pos)) if id == node_id => delta_pos,
-        //             _ => Vec2::ZERO,
-        //         };
-
-        //         viewport.grid.graph_to_canvas(node.pos()) + delta_pos
-        //     };
-
-        //     let mut node_painter = NodePainter::new();
-
-        //     let node_response = node::show_node(
-        //         &mut ui,
-        //         node_id.clone(),
-        //         node.ui(),
-        //         &mut socket_responses,
-        //         node.sockets(),
-        //         viewport.canvas_to_viewport(pos),
-        //         &mut node_painter,
-        //     );
-
-        //     if let Some(shape_id) = node_shape_indices.get(&node_id).copied() {
-        //         ui.painter().set(shape_id, node_painter);
-        //     } else {
-        //         ui.painter().add(node_painter);
-        //     }
-
-        //     if node_response.drag_stopped() {
-        //         state.dragged_node = None;
-        //         let new_pos = pos + node_response.drag_delta();
-        //         node.set_pos(viewport.grid.canvas_to_graph_nearest(new_pos));
-        //     } else if node_response.drag_started() {
-        //         state.dragged_node = Some((node_id.clone(), node_response.drag_delta()));
-        //     } else if node_response.dragged() {
-        //         if let Some(dragged_node) = state.dragged_node.as_mut() {
-        //             dragged_node.1 += node_response.drag_delta();
-        //         }
-        //     }
-
-        //     if node_response.clicked || node_response.fake_primary_click || node_response.dragged()
-        //     {
-        //         last_interacted_node_id = Some(node_id.clone());
-        //         state.set_node_on_top(node_id.clone());
-        //     }
-
-        //     node_responses.push((node_id, node_response));
-        // }
-
-        // drop(nodes);
-
-        if let Some(context_menu) = node_context_menu.as_mut() {
-            for (id, response) in node_responses {
+            if let Some(context_menu) = node_context_menu.as_mut() {
                 response.context_menu(|ui| {
                     context_menu(
                         ui,

--- a/examples/visual_math/src/app/graph/adapter.rs
+++ b/examples/visual_math/src/app/graph/adapter.rs
@@ -43,6 +43,10 @@ impl nodui::GraphAdapter for GraphApp {
         })
     }
 
+    fn set_node_pos(&mut self, node_id: Self::NodeId, pos: nodui::Pos) {
+        self.positions.insert(node_id, pos);
+    }
+
     fn connection_hint(&self, a: Self::SocketId, b: Self::SocketId) -> ConnectionHint {
         if crate::graph::Connections::can_connect(a, b) {
             ConnectionHint::Accept

--- a/examples/visual_math/src/app/graph/node.rs
+++ b/examples/visual_math/src/app/graph/node.rs
@@ -1,8 +1,5 @@
 //! Implementation of the nodui adapter traits for the nodes.
 
-use core::slice;
-use std::collections::HashMap;
-
 use either::Either;
 use nodui::ui::{Color, NodeUI};
 use nodui::Pos;
@@ -13,63 +10,16 @@ use super::socket::SocketIter;
 
 /* -------------------------------------------------------------------------- */
 
-/// An iterator over the node of the math graph.
-pub(super) struct NodeIter<'a> {
-    /// The operation nodes of the graph.
-    pub(super) nodes: slice::Iter<'a, OpNode>,
-    /// The input of the graph.
-    pub(super) inputs: slice::Iter<'a, Input>,
+/// An adapter for a node of the math graph.
+pub(super) struct NodeAdapter<'a> {
+    /// The current position of this node.
+    pub(super) pos: Pos,
+    /// The graph node.
+    pub(super) node: Either<&'a OpNode, &'a Input>,
     /// The connections of the graph.
     pub(super) connections: &'a Connections,
-    /// The positions of the nodes.
-    pub(super) positions: &'a mut HashMap<NodeId, Pos>,
     /// The currently selected node.
     pub(super) selected_node: Option<NodeId>,
-}
-
-impl nodui::NodeIterator for NodeIter<'_> {
-    type NodeId = NodeId;
-    type SocketId = SocketId;
-
-    type Item<'this> = NodeAdapter<'this>
-    where
-        Self: 'this;
-
-    fn next(&mut self) -> Option<Self::Item<'_>> {
-        if let Some(node) = self.nodes.next() {
-            let pos = self.positions.entry(node.id().into()).or_default();
-            return Some(NodeAdapter {
-                pos,
-                node: Either::Left(node),
-                connections: self.connections,
-                selected_node: self.selected_node,
-            });
-        }
-
-        self.inputs.next().map(|input| {
-            let pos = self.positions.entry(input.id().into()).or_default();
-            NodeAdapter {
-                pos,
-                node: Either::Right(input),
-                connections: self.connections,
-                selected_node: self.selected_node,
-            }
-        })
-    }
-}
-
-/* -------------------------------------------------------------------------- */
-
-/// An adapter for a node of the math graph.
-pub struct NodeAdapter<'a> {
-    /// The current position of this node.
-    pos: &'a mut Pos,
-    /// The graph node.
-    node: Either<&'a OpNode, &'a Input>,
-    /// The connections of the graph.
-    connections: &'a Connections,
-    /// The currently selected node.
-    selected_node: Option<NodeId>,
 }
 
 impl nodui::NodeAdapter for NodeAdapter<'_> {
@@ -89,11 +39,7 @@ impl nodui::NodeAdapter for NodeAdapter<'_> {
     }
 
     fn pos(&self) -> Pos {
-        *self.pos
-    }
-
-    fn set_pos(&mut self, pos: Pos) {
-        *self.pos = pos;
+        self.pos
     }
 
     fn ui(&self) -> NodeUI {

--- a/playground/src/app/adapter.rs
+++ b/playground/src/app/adapter.rs
@@ -30,6 +30,12 @@ impl<'a> nodui::GraphAdapter for GraphAdapter<'a> {
         nodes.iter().map(|node| NodeAdapter { node, connections })
     }
 
+    fn set_node_pos(&mut self, node_id: Self::NodeId, pos: Pos) {
+        if let Some(node) = self.graph.get_node_mut(node_id) {
+            node.set_pos(pos);
+        }
+    }
+
     fn connection_hint(&self, a: Self::SocketId, b: Self::SocketId) -> ConnectionHint {
         if crate::graph::connections::can_connect(a, b) {
             ConnectionHint::Accept

--- a/playground/src/app/adapter.rs
+++ b/playground/src/app/adapter.rs
@@ -21,13 +21,13 @@ impl<'a> nodui::GraphAdapter for GraphAdapter<'a> {
     type SocketId = SocketId;
 
     fn nodes(
-        &mut self,
-    ) -> impl nodui::NodeIterator<NodeId = Self::NodeId, SocketId = Self::SocketId> {
-        let (nodes, connections) = self.graph.nodes_and_connections_mut();
+        &self,
+    ) -> impl Iterator<Item: nodui::NodeAdapter<NodeId = Self::NodeId, SocketId = Self::SocketId>>
+    {
+        let nodes = self.graph.nodes();
+        let connections = self.graph.connections();
 
-        nodes
-            .iter_mut()
-            .map(|node| NodeAdapter { node, connections })
+        nodes.iter().map(|node| NodeAdapter { node, connections })
     }
 
     fn connection_hint(&self, a: Self::SocketId, b: Self::SocketId) -> ConnectionHint {
@@ -51,7 +51,7 @@ impl<'a> nodui::GraphAdapter for GraphAdapter<'a> {
 }
 
 struct NodeAdapter<'a> {
-    node: &'a mut DummyNode,
+    node: &'a DummyNode,
     connections: &'a Connections,
 }
 
@@ -80,10 +80,6 @@ impl<'a> nodui::NodeAdapter for NodeAdapter<'a> {
 
     fn pos(&self) -> Pos {
         self.node.pos()
-    }
-
-    fn set_pos(&mut self, pos: Pos) {
-        self.node.set_pos(pos);
     }
 
     fn ui(&self) -> NodeUI {

--- a/playground/src/graph/mod.rs
+++ b/playground/src/graph/mod.rs
@@ -102,16 +102,16 @@ pub struct DummySocket {
 /* -------------------------------------------------------------------------- */
 
 impl DummyGraph {
+    pub fn nodes(&self) -> &[DummyNode] {
+        &self.nodes
+    }
+
     pub fn connections(&self) -> &Connections {
         &self.connections
     }
 
     pub fn connections_mut(&mut self) -> &mut Connections {
         &mut self.connections
-    }
-
-    pub fn nodes_and_connections_mut(&mut self) -> (&mut [DummyNode], &mut Connections) {
-        (&mut self.nodes, &mut self.connections)
     }
 
     pub fn add_node(
@@ -176,10 +176,6 @@ impl DummyNode {
 
     pub fn pos(&self) -> Pos {
         self.pos
-    }
-
-    pub fn set_pos(&mut self, pos: Pos) {
-        self.pos = pos
     }
 }
 

--- a/playground/src/graph/mod.rs
+++ b/playground/src/graph/mod.rs
@@ -155,6 +155,10 @@ impl DummyGraph {
         self.nodes.iter().find(|n| id == n.id)
     }
 
+    pub fn get_node_mut(&mut self, id: NodeId) -> Option<&mut DummyNode> {
+        self.nodes.iter_mut().find(|n| id == n.id)
+    }
+
     // pub fn get_socket(&self, id: SocketId) -> Option<&DummySocket> {
     //     let node_id = id.node_id();
 
@@ -176,6 +180,10 @@ impl DummyNode {
 
     pub fn pos(&self) -> Pos {
         self.pos
+    }
+
+    pub fn set_pos(&mut self, pos: Pos) {
+        self.pos = pos;
     }
 }
 


### PR DESCRIPTION
## Changelog 
- Remove the trait `NodeIterator`
- Change the return type of `GraphAdapter::nodes()` to `impl Iterator`
- Change the mutability of `GraphAdapter::nodes()` from `&mut self` to `&self`
- Remove `NodeAdapter::set_pos`
- Add `GraphAdapter::set_node_pos()`